### PR TITLE
Added tests for described Exoskeleton functionality

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 3 ]; then
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]"
+	exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+SKIP_DB_CREATE=${6-false}
+
+WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib}
+WP_CORE_DIR=${WP_CORE_DIR-/tmp/wordpress/}
+
+download() {
+    if [ `which curl` ]; then
+        curl -s "$1" > "$2";
+    elif [ `which wget` ]; then
+        wget -nv -O "$2" "$1"
+    fi
+}
+
+if [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)? ]]; then
+	WP_TESTS_TAG="tags/$WP_VERSION"
+elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+	WP_TESTS_TAG="trunk"
+else
+	# http serves a single offer, whereas https serves multiple. we only want one
+	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
+	grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
+	LATEST_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+	if [[ -z "$LATEST_VERSION" ]]; then
+		echo "Latest WordPress version could not be found"
+		exit 1
+	fi
+	WP_TESTS_TAG="tags/$LATEST_VERSION"
+fi
+
+set -ex
+
+install_wp() {
+
+	if [ -d $WP_CORE_DIR ]; then
+		return;
+	fi
+
+	mkdir -p $WP_CORE_DIR
+
+	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+		mkdir -p /tmp/wordpress-nightly
+		download https://wordpress.org/nightly-builds/wordpress-latest.zip  /tmp/wordpress-nightly/wordpress-nightly.zip
+		unzip -q /tmp/wordpress-nightly/wordpress-nightly.zip -d /tmp/wordpress-nightly/
+		mv /tmp/wordpress-nightly/wordpress/* $WP_CORE_DIR
+	else
+		if [ $WP_VERSION == 'latest' ]; then
+			local ARCHIVE_NAME='latest'
+		else
+			local ARCHIVE_NAME="wordpress-$WP_VERSION"
+		fi
+		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
+		tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
+	fi
+
+	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+}
+
+install_test_suite() {
+	# portable in-place argument for both GNU sed and Mac OSX sed
+	if [[ $(uname -s) == 'Darwin' ]]; then
+		local ioption='-i .bak'
+	else
+		local ioption='-i'
+	fi
+
+	# set up testing suite if it doesn't yet exist
+	if [ ! -d $WP_TESTS_DIR ]; then
+		# set up testing suite
+		mkdir -p $WP_TESTS_DIR
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
+	fi
+
+	if [ ! -f wp-tests-config.php ]; then
+		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
+		# remove all forward slashes in the end
+		WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
+	fi
+
+}
+
+install_db() {
+
+	if [ ${SKIP_DB_CREATE} = "true" ]; then
+		return 0
+	fi
+
+	# parse DB_HOST for port or socket references
+	local PARTS=(${DB_HOST//\:/ })
+	local DB_HOSTNAME=${PARTS[0]};
+	local DB_SOCK_OR_PORT=${PARTS[1]};
+	local EXTRA=""
+
+	if ! [ -z $DB_HOSTNAME ] ; then
+		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
+			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
+		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
+			EXTRA=" --socket=$DB_SOCK_OR_PORT"
+		elif ! [ -z $DB_HOSTNAME ] ; then
+			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
+		fi
+	fi
+
+	# create database
+	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+}
+
+install_wp
+install_test_suite
+install_db

--- a/classes/class-exoskeleton.php
+++ b/classes/class-exoskeleton.php
@@ -292,7 +292,14 @@ class Exoskeleton {
 		@header( "Cache-Control: public max-age=$retry_after" );
 		status_header( 429, 'Exoskeleton: too many requests for this endpoint.  Please consult Retry-After and come back later.  Meanwhile enjoy a well-deserved REST' );
 		@header( "Retry-After: $retry_after" );
+
+		// Do not die if testing.
+		if ( defined( 'PHPUNIT_EXOSKELETON_TESTING' ) ) {
+			throw new Exception('locked');
+		}
+
 		die();
+
 	}
 
 	/**

--- a/classes/class-exoskeleton.php
+++ b/classes/class-exoskeleton.php
@@ -295,7 +295,7 @@ class Exoskeleton {
 
 		// Do not die if testing.
 		if ( defined( 'PHPUNIT_EXOSKELETON_TESTING' ) ) {
-			throw new Exception('locked');
+			throw new Exception( 'locked' );
 		}
 
 		die();

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Coding Standards for Plugins">
+	<description>Generally-applicable sniffs for WordPress plugins</description>
+
+	<rule ref="WordPress-Core" />
+	<rule ref="WordPress-Docs" />
+
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+</ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,24 @@
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<testsuites>
+		<testsuite>
+			<directory prefix="test-" suffix=".php">./tests/</directory>
+		</testsuite>
+	</testsuites>
+	<filter>
+		<whitelist processUncoveredFilesFromWhitelist="true" >
+		  <directory suffix=".php">.</directory>
+		  <file>exoskeleton.php</file>
+		  <file>classes/class-exoskeleton.php</file>
+		</whitelist>
+	</filter>
+	<php>
+	   <const name="PHPUNIT_EXOSKELETON_TESTING" value="true"/>
+	</php>
+</phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,8 +12,7 @@
 		</testsuite>
 	</testsuites>
 	<filter>
-		<whitelist processUncoveredFilesFromWhitelist="true" >
-		  <directory suffix=".php">.</directory>
+		<whitelist processUncoveredFilesFromWhitelist="false" >
 		  <file>exoskeleton.php</file>
 		  <file>classes/class-exoskeleton.php</file>
 		</whitelist>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,7 +7,7 @@
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 if ( ! $_tests_dir ) {
-	$_tests_dir = dirname( __FILE__ ).'/../../../../wordpress-tests-lib';
+	$_tests_dir = dirname( __FILE__ ) . '/../../../../wordpress-tests-lib';
 }
 
 // Give access to tests_add_filter() function.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * PHPUnit bootstrap file
+ *
+ * @package Exoskeleton
+ */
+
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+if ( ! $_tests_dir ) {
+	$_tests_dir = dirname( __FILE__ ).'/../../../../wordpress-tests-lib';
+}
+
+// Give access to tests_add_filter() function.
+require_once $_tests_dir . '/includes/functions.php';
+
+/**
+ * Manually load the plugin being tested.
+ */
+function _manually_load_plugin() {
+	require dirname( dirname( __FILE__ ) ) . '/exoskeleton.php';
+}
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
+// Start up the WP testing environment.
+require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/test-exoskeleton-add-rule.php
+++ b/tests/test-exoskeleton-add-rule.php
@@ -155,12 +155,5 @@ class ExoskeletonAddRuleTest extends WP_UnitTestCase {
 		$this->assertTrue( exoskeleton_add_rule( $args ) );
 	}
 
-	/**
-	 * Test route is not limited
-	 */
-	function test_route_is_not_limited() {
-		$this->assertTrue( exoskeleton_add_rule( $this::$single_valid_rule ) );
-
-	}
 
 }

--- a/tests/test-exoskeleton-add-rule.php
+++ b/tests/test-exoskeleton-add-rule.php
@@ -36,6 +36,7 @@ class ExoskeletonAddRuleTest extends WP_UnitTestCase {
 			'limit'	=> 2,
 			'lockout' => 30,
 			'method' => 'any',
+			'treat_head_like_get' => false,
 		);
 
 		self::$three_valid_rules = array(
@@ -177,6 +178,24 @@ class ExoskeletonAddRuleTest extends WP_UnitTestCase {
 		$exoskeleton = Exoskeleton::get_instance();
 		$this->assertTrue( exoskeleton_add_rule( $this::$single_valid_rule ) );
 		$this->assertFalse( $exoskeleton->add_rule( $this::$single_valid_rule ) );
+	}
+
+	/**
+	 * Check that exoskeleton validates rules with false rule
+	 */
+	function test_internal_validate_rule_method_fails_when_adding_invalid_rule() {
+		$exoskeleton = Exoskeleton::get_instance();
+		$invalid_rule = $this::$single_valid_rule;
+		unset( $invalid_rule['method'] );
+		$this->assertFalse( $exoskeleton->validate_rule( $invalid_rule ) );
+	}
+
+	/**
+	 * Check that exoskeleton validates rules with valid rule
+	 */
+	function test_internal_validate_rule_method_fails_when_adding_a_valid_rule() {
+		$exoskeleton = Exoskeleton::get_instance();
+		$this->assertTrue( $exoskeleton->validate_rule( $this::$single_valid_rule ) );
 	}
 
 }

--- a/tests/test-exoskeleton-add-rule.php
+++ b/tests/test-exoskeleton-add-rule.php
@@ -53,6 +53,7 @@ class ExoskeletonAddRuleTest extends WP_UnitTestCase {
     function setUp() {
 		$instance = Exoskeleton::get_instance();
 		$instance->rules = [];
+
     }
 
 	/**
@@ -154,6 +155,5 @@ class ExoskeletonAddRuleTest extends WP_UnitTestCase {
 
 		$this->assertTrue( exoskeleton_add_rule( $args ) );
 	}
-
 
 }

--- a/tests/test-exoskeleton-add-rule.php
+++ b/tests/test-exoskeleton-add-rule.php
@@ -20,33 +20,33 @@ class ExoskeletonAddRuleTest extends WP_UnitTestCase {
 		parent::setUpBeforeClass();
 
 		self::$single_valid_rule = array(
-				'route' => '/wp/v2/posts',
-				'window' => 5,
-				'limit'	=> 2,
-				'lockout' => 30,
-				'method' => 'any',
+			'route' => '/wp/v2/posts',
+			'window' => 5,
+			'limit'	=> 2,
+			'lockout' => 30,
+			'method' => 'any',
 		);
 
 		self::$three_valid_rules = array(
-				[
-					'route' => '/wp/v2/posts',
-					'window' => 10,
-					'limit'	=> 25,
-					'lockout' => 200,
-					'method' => 'any',
-				],[
-					'route' => '/wp/v2/post/1',
-					'window' => 100,
-					'limit'	=> 5,
-					'lockout' => 60,
-					'method' => 'GET',
-				],[
-					'route' => '/wp/v2/post/2',
-					'window' => 90,
-					'limit'	=> 2,
-					'lockout' => 30,
-					'method' => 'GET',
-				]
+			[
+				'route' => '/wp/v2/posts',
+				'window' => 10,
+				'limit'	=> 25,
+				'lockout' => 200,
+				'method' => 'any',
+			],[
+				'route' => '/wp/v2/post/1',
+				'window' => 100,
+				'limit'	=> 5,
+				'lockout' => 60,
+				'method' => 'GET',
+			],[
+				'route' => '/wp/v2/post/2',
+				'window' => 90,
+				'limit'	=> 2,
+				'lockout' => 30,
+				'method' => 'GET',
+			]
 		);
 	}
 

--- a/tests/test-exoskeleton-add-rule.php
+++ b/tests/test-exoskeleton-add-rule.php
@@ -170,4 +170,13 @@ class ExoskeletonAddRuleTest extends WP_UnitTestCase {
 		$this->assertTrue( exoskeleton_add_rule( $args ) );
 	}
 
+	/**
+	 * Check that exoskeleton will not overwrite an already existing rule
+	 */
+	function test_internal_add_rule_method_fails_when_adding_existing_rule() {
+		$exoskeleton = Exoskeleton::get_instance();
+		$this->assertTrue( exoskeleton_add_rule( $this::$single_valid_rule ) );
+		$this->assertFalse( $exoskeleton->add_rule( $this::$single_valid_rule ) );
+	}
+
 }

--- a/tests/test-exoskeleton-add-rule.php
+++ b/tests/test-exoskeleton-add-rule.php
@@ -10,7 +10,18 @@
  */
 class ExoskeletonAddRuleTest extends WP_UnitTestCase {
 
+	/**
+	 * One rule definition
+	 *
+	 * @var array A single valid rule definition
+	 */
 	protected static $single_valid_rule;
+
+	/**
+	 * Three rule definitions
+	 *
+	 * @var array Three valid rule definitions
+	 */
 	protected static $three_valid_rules;
 
 	/**
@@ -46,15 +57,18 @@ class ExoskeletonAddRuleTest extends WP_UnitTestCase {
 				'limit'	=> 2,
 				'lockout' => 30,
 				'method' => 'GET',
-			]
+			],
 		);
 	}
 
-    function setUp() {
+	/**
+	 * Pre test setup
+	 */
+	function setUp() {
 		$instance = Exoskeleton::get_instance();
 		$instance->rules = [];
 
-    }
+	}
 
 	/**
 	 * Get instance of Exoskeleton

--- a/tests/test-exoskeleton-add-rule.php
+++ b/tests/test-exoskeleton-add-rule.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Class ExoskeletonTest
+ *
+ * @package Exoskeleton
+ */
+
+/**
+ * Sample test case.
+ */
+class ExoskeletonAddRuleTest extends WP_UnitTestCase {
+
+	protected static $single_valid_rule;
+	protected static $three_valid_rules;
+
+	/**
+	 * Define some valid rule sets to reduce duplication in tests.
+	 */
+	static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		self::$single_valid_rule = array(
+				'route' => '/wp/v2/posts',
+				'window' => 5,
+				'limit'	=> 2,
+				'lockout' => 30,
+				'method' => 'any',
+		);
+
+		self::$three_valid_rules = array(
+				[
+					'route' => '/wp/v2/posts',
+					'window' => 10,
+					'limit'	=> 25,
+					'lockout' => 200,
+					'method' => 'any',
+				],[
+					'route' => '/wp/v2/post/1',
+					'window' => 100,
+					'limit'	=> 5,
+					'lockout' => 60,
+					'method' => 'GET',
+				],[
+					'route' => '/wp/v2/post/2',
+					'window' => 90,
+					'limit'	=> 2,
+					'lockout' => 30,
+					'method' => 'GET',
+				]
+		);
+	}
+
+    function setUp() {
+		$instance = Exoskeleton::get_instance();
+		$instance->rules = [];
+    }
+
+	/**
+	 * Get instance of Exoskeleton
+	 */
+	function test_get_instance() {
+		$this->assertInstanceOf( Exoskeleton::class, Exoskeleton::get_instance() );
+	}
+
+	/**
+	 * Test adding a valid rule
+	 */
+	function test_add_valid_rule() {
+
+		$this->assertTrue( exoskeleton_add_rule( $this::$single_valid_rule ) );
+	}
+
+	/**
+	 * Test adding a valid rule - missing method
+	 */
+	function test_add_valid_rule_missing_method() {
+		$args =	$this::$single_valid_rule;
+		unset( $args['method'] );
+
+		$this->assertTrue( exoskeleton_add_rule( $args ) );
+	}
+
+	/**
+	 * Test adding an invalid rule - missing route
+	 */
+	function test_add_invalid_rule_missing_route() {
+		$args =	$this::$single_valid_rule;
+		unset( $args['route'] );
+
+		$this->assertFalse( exoskeleton_add_rule( $args ) );
+	}
+
+	/**
+	 * Test adding an invalid rule - missing window
+	 */
+	function test_add_invalid_rule_missing_window() {
+		$args =	$this::$single_valid_rule;
+		unset( $args['window'] );
+
+		$this->assertFalse( exoskeleton_add_rule( $args ) );
+	}
+
+	/**
+	 * Test adding an invalid rule - missing limit
+	 */
+	function test_add_invalid_rule_missing_limit() {
+		$args =	$this::$single_valid_rule;
+		unset( $args['limit'] );
+
+		$this->assertFalse( exoskeleton_add_rule( $args ) );
+	}
+
+	/**
+	 * Test adding an invalid rule - missing lockout
+	 */
+	function test_add_invalid_rule_missing_lockout() {
+		$args =	$this::$single_valid_rule;
+		unset( $args['lockout'] );
+
+		$this->assertFalse( exoskeleton_add_rule( $args ) );
+	}
+
+	/**
+	 * Test adding multiple valid rules
+	 */
+	function test_adding_multiple_valid_rules() {
+		$args =	$this::$three_valid_rules;
+
+		$this->assertNull( exoskeleton_add_rules( $args ) );
+		$instance = Exoskeleton::get_instance();
+		$this->assertEquals( 3, count( $instance->rules ) );
+	}
+
+
+	/**
+	 * Test adding multiple rules including invalid
+	 */
+	function test_adding_multiple_rules_including_invalid() {
+		$args =	$this::$three_valid_rules;
+		unset( $args[1]['lockout'] );
+
+		$this->assertNull( exoskeleton_add_rules( $args ) );
+		$instance = Exoskeleton::get_instance();
+		$this->assertEquals( 2, count( $instance->rules ) );
+	}
+
+	/**
+	 * Test adding a valid rule for a custom route
+	 * Exoskeleton makes no check for existence of custom route.
+	 */
+	function test_add_valid_custom_route_rule() {
+		$args =	$this::$single_valid_rule;
+		$args['route'] = '/custom/route/that/does/not/exist';
+
+		$this->assertTrue( exoskeleton_add_rule( $args ) );
+	}
+
+	/**
+	 * Test route is not limited
+	 */
+	function test_route_is_not_limited() {
+		$this->assertTrue( exoskeleton_add_rule( $this::$single_valid_rule ) );
+
+	}
+
+}

--- a/tests/test-exoskeleton-rest-api-calls.php
+++ b/tests/test-exoskeleton-rest-api-calls.php
@@ -22,11 +22,11 @@ class ExoskeletonRestApiCallsTest extends WP_UnitTestCase {
 		parent::setUpBeforeClass();
 
 		self::$single_valid_rule = array(
-				'route' => '/wp/v2/posts',
-				'window' => 5,
-				'limit'	=> 1,
-				'lockout' => 5,
-				'method' => 'any',
+			'route' => '/wp/v2/posts',
+			'window' => 5,
+			'limit'	=> 1,
+			'lockout' => 5,
+			'method' => 'any',
 		);
 	}
 

--- a/tests/test-exoskeleton-rest-api-calls.php
+++ b/tests/test-exoskeleton-rest-api-calls.php
@@ -11,7 +11,10 @@
 class ExoskeletonRestApiCallsTest extends WP_UnitTestCase {
 
 
-    function setUp() {
+	/**
+	 * Pre test setup
+	 */
+	function setUp() {
 		parent::setUp();
 
 		// Clear existing rules.
@@ -20,43 +23,54 @@ class ExoskeletonRestApiCallsTest extends WP_UnitTestCase {
 
 		add_action( 'rest_api_init', function () {
 			register_rest_route( 'exoskeleton/v1', '/exoskeleton/(?P<id>\d+)', array(
-			  'methods' => 'GET',
-			  'callback' => [ $this, 'custom_route_callback' ],
+				'methods' => 'GET',
+				'callback' => [ $this, 'custom_route_callback' ],
 			) );
 		} );
-    }
+	}
 
 
 	/**
 	 * Test key generation
-     * @dataProvider limitTestingProvider
-     */
+	 *
+	 * @dataProvider limitTestingProvider
+	 * @param array $rule exoskeleton rule array.
+	 * @param array $test extra test data.
+	 */
 	public function test_key_generation( $rule, $test ) {
 		exoskeleton_add_rule( $rule );
 		$exoskeleton = Exoskeleton::get_instance();
-		$this->assertEquals( $test['key'], key($exoskeleton->rules) );
+		$this->assertEquals( $test['key'], key( $exoskeleton->rules ) );
 	}
 
 	/**
 	 * Simple method to provide a callback for custom routes during testing
-	 * @param mixed $data
-	 * @return mixed
+	 *
+	 * @param mixed $data data passed into the request for this route.
+	 * @return mixed returns the data that was input to provide a valid output.
 	 */
 	public function custom_route_callback( $data ) {
 		return $data;
 	}
 
 
+	/**
+	 * Check limits are honoured if a route is registered with exoskeleton limits.
+	 */
 	function test_pre_registered_custom_route_rules() {
 
 		add_action( 'rest_api_init', function () {
 			register_rest_route( 'exoskeleton/v1', '/test/(?P<id>\d+)', array(
-			  'methods' => 'GET',
-			  'callback' => [ $this, 'custom_route_callback' ],
-			  'exoskeleton' => [ 'window' => 10, 'limit'    => 5, 'lockout' => 20 ],
+				'methods' => 'GET',
+				'callback' => [ $this, 'custom_route_callback' ],
+				'exoskeleton' => [
+				  'window' => 10,
+				  'limit' => 5,
+				  'lockout' => 20,
+				],
 			) );
 		} );
-        for( $request = 1; $request <= 6; ++$request ) {
+		for ( $request = 1; $request <= 6; ++$request ) {
 			if ( $request < 5 ) {
 				$response = rest_do_request( new WP_REST_Request( 'GET', '/exoskeleton/v1/test/1' ) );
 				$this->assertEquals( 200, $response->status );
@@ -71,14 +85,17 @@ class ExoskeletonRestApiCallsTest extends WP_UnitTestCase {
 
 	/**
 	 * Check that requests do get properly limited
-     * @dataProvider limitTestingProvider
-     */
-    public function test_limits_are_applied( $rule, $test ) {
+	 *
+	 * @dataProvider limitTestingProvider
+	 * @param array $rule exoskeleton rule array.
+	 * @param array $test extra test data.
+	 */
+	public function test_limits_are_applied( $rule, $test ) {
 		if ( empty( $test['method'] ) ) {
 			$test['method'] = $rule['method'];
 		}
 		$this->assertTrue( exoskeleton_add_rule( $rule ) );
-        for( $request = 1; $request <= $rule['limit'] + 1; ++$request ) {
+		for ( $request = 1; $request <= $rule['limit'] + 1; ++$request ) {
 			if ( $request < $rule['limit'] ) {
 				$response = rest_do_request( new WP_REST_Request( $test['method'], $rule['route'] ) );
 				$this->assertEquals( 200, $response->status );
@@ -88,19 +105,22 @@ class ExoskeletonRestApiCallsTest extends WP_UnitTestCase {
 				$response = rest_do_request( new WP_REST_Request( $test['method'], $rule['route'] ) );
 			}
 		}
-    }
+	}
 
 
 	/**
-	 * Make sure that requests falling outside the window do not get imited.
-     * @dataProvider limitTestingProvider
-     */
-    public function test_limit_window_expiry( $rule, $test ) {
+	 * Make sure that requests falling outside the window do not get limited.
+	 *
+	 * @dataProvider limitTestingProvider
+	 * @param array $rule exoskeleton rule array.
+	 * @param array $test extra test data.
+	 */
+	public function test_limit_window_expiry( $rule, $test ) {
 		if ( empty( $test['method'] ) ) {
 			$test['method'] = $rule['method'];
 		}
 		$this->assertTrue( exoskeleton_add_rule( $rule ) );
-        for( $request = 1; $request <= $rule['limit'] + 1; ++$request ) {
+		for ( $request = 1; $request <= $rule['limit'] + 1; ++$request ) {
 			if ( $request < $rule['limit'] ) {
 				$response = rest_do_request( new WP_REST_Request( $test['method'], $rule['route'] ) );
 				$this->assertEquals( 200, $response->status );
@@ -110,31 +130,38 @@ class ExoskeletonRestApiCallsTest extends WP_UnitTestCase {
 				$this->assertEquals( 200, $response->status );
 			}
 		}
-    }
+	}
 
 	/**
 	 * Limits should only be applied if the correct method is requested
-     * @dataProvider limitTestingProvider
-     */
-    public function test_different_methods_not_limited( $rule, $test ) {
-		// Change the test method
+	 *
+	 * @dataProvider limitTestingProvider
+	 * @param array $rule exoskeleton rule array.
+	 * @param array $test extra test data.
+	 */
+	public function test_different_methods_not_limited( $rule, $test ) {
+		// Change the test or rule method for testing.
 		if ( empty( $test['method'] ) ) {
 			$test['method'] = 'HEAD';
 		} else {
 			$rule['method'] = 'POST';
 		}
 		$this->assertTrue( exoskeleton_add_rule( $rule ) );
-        for( $request = 1; $request <= $rule['limit'] + 1; ++$request ) {
+		for ( $request = 1; $request <= $rule['limit'] + 1; ++$request ) {
 			$response = rest_do_request( new WP_REST_Request( $test['method'], $rule['route'] ) );
 			$this->assertEquals( 200, $response->status );
 		}
-    }
+	}
 
 
 
-
+	/**
+	 * Data provider
+	 *
+	 * @return array exoskeleton rule information and test data.
+	 */
 	public function limitTestingProvider() {
-        return [
+		return [
 			[
 				'rule' => [
 					'route' => '/wp/v2/posts',
@@ -146,7 +173,7 @@ class ExoskeletonRestApiCallsTest extends WP_UnitTestCase {
 				],
 				'test' => [
 					'key' => '01dd28291a6b5b95802281831ec3d6f5_GET',
-				]
+				],
 			],
 			[
 				'rule' => [
@@ -159,7 +186,7 @@ class ExoskeletonRestApiCallsTest extends WP_UnitTestCase {
 				],
 				'test' => [
 					'key' => 'fd568c1eb104fbad04765b9f2f0100ed_GET',
-				]
+				],
 			],
 			[
 				'rule' => [
@@ -173,7 +200,7 @@ class ExoskeletonRestApiCallsTest extends WP_UnitTestCase {
 				'test' => [
 					'method' => 'HEAD',
 					'key' => '6ae5a5054b0a306061f10b9c1b193183_GET',
-				]
+				],
 			],
 			[
 				'rule' => [
@@ -186,9 +213,9 @@ class ExoskeletonRestApiCallsTest extends WP_UnitTestCase {
 				],
 				'test' => [
 					'key' => 'b09a74d523deb0962e21cafaadc63679_GET',
-				]
+				],
 			],
 		];
-    }
+	}
 
 }

--- a/tests/test-exoskeleton-rest-api-calls.php
+++ b/tests/test-exoskeleton-rest-api-calls.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Class ExoskeletonTest
+ *
+ * @package Exoskeleton
+ */
+
+/**
+ * Sample test case.
+ */
+class ExoskeletonRestApiCallsTest extends WP_UnitTestCase {
+
+	protected static $single_valid_rule;
+	protected static $three_valid_rules;
+
+	protected $server;
+
+	/**
+	 * Define some valid rule sets to reduce duplication in tests.
+	 */
+	static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		self::$single_valid_rule = array(
+				'route' => '/wp/v2/posts',
+				'window' => 5,
+				'limit'	=> 1,
+				'lockout' => 5,
+				'method' => 'any',
+		);
+	}
+
+    function setUp() {
+		parent::setUp();
+
+		// Clear existing rules.
+		$instance = Exoskeleton::get_instance();
+		$instance->rules = [];
+
+		exoskeleton_add_rule( $this::$single_valid_rule );
+
+    }
+
+	/**
+	 * Test route is not limited
+	 */
+	function test_route_is_not_limited() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$response = rest_do_request($request);
+		$this->assertEquals( 200, $response->status );
+	}
+
+	/**
+	 * Test route has been restricted
+	 */
+	function test_route_is_limited() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$response = rest_do_request($request);
+		$this->assertEquals( 200, $response->status );
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('locked');
+		$response = rest_do_request($request);
+	}
+
+}

--- a/tests/test-exoskeleton-rest-api-calls.php
+++ b/tests/test-exoskeleton-rest-api-calls.php
@@ -10,6 +10,7 @@
  */
 class ExoskeletonRestApiCallsTest extends WP_UnitTestCase {
 
+
     function setUp() {
 		parent::setUp();
 
@@ -17,27 +18,74 @@ class ExoskeletonRestApiCallsTest extends WP_UnitTestCase {
 		$instance = Exoskeleton::get_instance();
 		$instance->rules = [];
 
-
+		add_action( 'rest_api_init', function () {
+			register_rest_route( 'exoskeleton/v1', '/exoskeleton/(?P<id>\d+)', array(
+			  'methods' => 'GET',
+			  'callback' => [ $this, 'custom_route_callback' ],
+			) );
+		} );
     }
+
+
+	/**
+	 * Test key generation
+     * @dataProvider limitTestingProvider
+     */
+	public function test_key_generation( $rule, $test ) {
+		exoskeleton_add_rule( $rule );
+		$exoskeleton = Exoskeleton::get_instance();
+		$this->assertEquals( $test['key'], key($exoskeleton->rules) );
+	}
+
+	/**
+	 * Simple method to provide a callback for custom routes during testing
+	 * @param mixed $data
+	 * @return mixed
+	 */
+	public function custom_route_callback( $data ) {
+		return $data;
+	}
+
+
+	function test_pre_registered_custom_route_rules() {
+
+		add_action( 'rest_api_init', function () {
+			register_rest_route( 'exoskeleton/v1', '/test/(?P<id>\d+)', array(
+			  'methods' => 'GET',
+			  'callback' => [ $this, 'custom_route_callback' ],
+			  'exoskeleton' => [ 'window' => 10, 'limit'    => 5, 'lockout' => 20 ],
+			) );
+		} );
+        for( $request = 1; $request <= 6; ++$request ) {
+			if ( $request < 5 ) {
+				$response = rest_do_request( new WP_REST_Request( 'GET', '/exoskeleton/v1/test/1' ) );
+				$this->assertEquals( 200, $response->status );
+			} else {
+				$this->expectException( Exception::class );
+				$this->expectExceptionMessage( 'locked' );
+				$response = rest_do_request( new WP_REST_Request( 'GET', '/exoskeleton/v1/test/1' ) );
+			}
+		}
+	}
+
 
 	/**
 	 * Check that requests do get properly limited
      * @dataProvider limitTestingProvider
      */
-    public function test_limits_are_applied( $rule, $test_method = false )
-    {
-		if ( empty( $test_method ) ) {
-			$test_method = $rule['method'];
+    public function test_limits_are_applied( $rule, $test ) {
+		if ( empty( $test['method'] ) ) {
+			$test['method'] = $rule['method'];
 		}
 		$this->assertTrue( exoskeleton_add_rule( $rule ) );
         for( $request = 1; $request <= $rule['limit'] + 1; ++$request ) {
 			if ( $request < $rule['limit'] ) {
-				$response = rest_do_request( new WP_REST_Request( $test_method, $rule['route'] ) );
+				$response = rest_do_request( new WP_REST_Request( $test['method'], $rule['route'] ) );
 				$this->assertEquals( 200, $response->status );
 			} else {
 				$this->expectException( Exception::class );
 				$this->expectExceptionMessage( 'locked' );
-				$response = rest_do_request( new WP_REST_Request( $test_method, $rule['route'] ) );
+				$response = rest_do_request( new WP_REST_Request( $test['method'], $rule['route'] ) );
 			}
 		}
     }
@@ -47,19 +95,18 @@ class ExoskeletonRestApiCallsTest extends WP_UnitTestCase {
 	 * Make sure that requests falling outside the window do not get imited.
      * @dataProvider limitTestingProvider
      */
-    public function test_limit_window_expiry( $rule, $test_method = false )
-    {
-		if ( empty( $test_method ) ) {
-			$test_method = $rule['method'];
+    public function test_limit_window_expiry( $rule, $test ) {
+		if ( empty( $test['method'] ) ) {
+			$test['method'] = $rule['method'];
 		}
 		$this->assertTrue( exoskeleton_add_rule( $rule ) );
         for( $request = 1; $request <= $rule['limit'] + 1; ++$request ) {
 			if ( $request < $rule['limit'] ) {
-				$response = rest_do_request( new WP_REST_Request( $test_method, $rule['route'] ) );
+				$response = rest_do_request( new WP_REST_Request( $test['method'], $rule['route'] ) );
 				$this->assertEquals( 200, $response->status );
 			} else {
 				sleep( $rule['window'] + 1 );
-				$response = rest_do_request( new WP_REST_Request( $test_method, $rule['route'] ) );
+				$response = rest_do_request( new WP_REST_Request( $test['method'], $rule['route'] ) );
 				$this->assertEquals( 200, $response->status );
 			}
 		}
@@ -69,58 +116,78 @@ class ExoskeletonRestApiCallsTest extends WP_UnitTestCase {
 	 * Limits should only be applied if the correct method is requested
      * @dataProvider limitTestingProvider
      */
-    public function test_different_methods_not_limited( $rule, $test_method = false )
-    {
+    public function test_different_methods_not_limited( $rule, $test ) {
 		// Change the test method
-		if ( empty( $test_method ) ) {
-			$test_method = 'HEAD';
+		if ( empty( $test['method'] ) ) {
+			$test['method'] = 'HEAD';
 		} else {
-			$this->assertNull( null ); // TODO Test third request with valid method
-			return;
+			$rule['method'] = 'POST';
 		}
 		$this->assertTrue( exoskeleton_add_rule( $rule ) );
         for( $request = 1; $request <= $rule['limit'] + 1; ++$request ) {
-			$response = rest_do_request( new WP_REST_Request( $test_method, $rule['route'] ) );
+			$response = rest_do_request( new WP_REST_Request( $test['method'], $rule['route'] ) );
 			$this->assertEquals( 200, $response->status );
 		}
     }
 
 
 
-	public function limitTestingProvider()
-    {
+
+	public function limitTestingProvider() {
         return [
 			[
-				array(
+				'rule' => [
 					'route' => '/wp/v2/posts',
-					'window' => 5,
+					'window' => 1,
 					'limit'	=> 3,
 					'lockout' => 5,
 					'method' => 'GET',
 					'treat_head_like_get' => false,
-				)
+				],
+				'test' => [
+					'key' => '01dd28291a6b5b95802281831ec3d6f5_GET',
+				]
 			],
 			[
-				array(
+				'rule' => [
 					'route' => '/wp/v2/categories',
 					'window' => 2,
-					'limit'	=> 10,
+					'limit'	=> 6,
 					'lockout' => 5,
 					'method' => 'GET',
 					'treat_head_like_get' => false,
-				)
+				],
+				'test' => [
+					'key' => 'fd568c1eb104fbad04765b9f2f0100ed_GET',
+				]
 			],
 			[
-				array(
+				'rule' => [
 					'route' => '/wp/v2/categories',
 					'window' => 2,
 					'limit'	=> 10,
 					'lockout' => 5,
 					'method' => 'GET',
 					'treat_head_like_get' => true,
-				),
-				'HEAD',
-			]
+				],
+				'test' => [
+					'method' => 'HEAD',
+					'key' => '6ae5a5054b0a306061f10b9c1b193183_GET',
+				]
+			],
+			[
+				'rule' => [
+					'route' => '/exoskeleton/v1/exoskeleton/10',
+					'window' => 1,
+					'limit'	=> 3,
+					'lockout' => 5,
+					'method' => 'GET',
+					'treat_head_like_get' => false,
+				],
+				'test' => [
+					'key' => 'b09a74d523deb0962e21cafaadc63679_GET',
+				]
+			],
 		];
     }
 

--- a/tests/test-exoskeleton-rest-api-calls.php
+++ b/tests/test-exoskeleton-rest-api-calls.php
@@ -50,7 +50,7 @@ class ExoskeletonRestApiCallsTest extends WP_UnitTestCase {
 	 * @return mixed returns the data that was input to provide a valid output.
 	 */
 	public function custom_route_callback( $data ) {
-		return new WP_REST_Response($data, 200);
+		return new WP_REST_Response( $data, 200 );
 	}
 
 
@@ -204,7 +204,7 @@ class ExoskeletonRestApiCallsTest extends WP_UnitTestCase {
 				// Initially test with one method
 				$response = rest_do_request( new WP_REST_Request( $test['method'], $rule['route'] ) );
 				$this->assertEquals( 200, $response->status );
-			} elseif ( $request == ( $rule['limit'] - 1 ) ) {
+			} elseif ( ( $rule['limit'] - 1 ) === $request ) {
 				// Test second method allowed
 				$test['method'] = 'HEAD';
 				$response = rest_do_request( new WP_REST_Request( $test['method'], $rule['route'] ) );

--- a/tests/test-exoskeleton-rule_validation.php
+++ b/tests/test-exoskeleton-rule_validation.php
@@ -126,22 +126,34 @@ class ExoskeletonRuleValidationTest extends WP_UnitTestCase {
 	public function invalidFieldValueProvider() {
 		return [
 			[
-				[ 'window' => 'string', ],
+				[
+					'window' => 'string',
+				],
 			],
 			[
-				[ 'window' => -1, ],
+				[
+					'window' => -1,
+				],
 			],
 			[
-				[ 'limit' => 'string', ],
+				[
+					'limit' => 'string',
+				],
 			],
 			[
-				[ 'limit' => -1, ],
+				[
+					'limit' => -1,
+				],
 			],
 			[
-				[ 'lockout' => 'string', ],
+				[
+					'lockout' => 'string',
+				],
 			],
 			[
-				[ 'treat_head_like_get' => 'string', ],
+				[
+					'treat_head_like_get' => 'string',
+				],
 			],
 		];
 	}

--- a/tests/test-exoskeleton-rule_validation.php
+++ b/tests/test-exoskeleton-rule_validation.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * Class ExoskeletonTest
+ *
+ * @package Exoskeleton
+ */
+
+/**
+ * Sample test case.
+ */
+class ExoskeletonRestApiCallsTest extends WP_UnitTestCase {
+
+
+	/**
+	 * Pre test setup
+	 */
+	function setUp() {
+		parent::setUp();
+
+		// Clear existing rules.
+		$instance = Exoskeleton::get_instance();
+		$instance->rules = [];
+
+		add_action( 'rest_api_init', function () {
+			register_rest_route( 'exoskeleton/v1', '/exoskeleton/(?P<id>\d+)', array(
+				'methods' => 'GET',
+				'callback' => [ $this, 'custom_route_callback' ],
+			) );
+		} );
+	}
+
+
+	/**
+	 * Test key generation
+	 *
+	 * @dataProvider limitTestingProvider
+	 * @param array $rule exoskeleton rule array.
+	 * @param array $test extra test data.
+	 */
+	public function test_key_generation( $rule, $test ) {
+		exoskeleton_add_rule( $rule );
+		$exoskeleton = Exoskeleton::get_instance();
+		$this->assertEquals( $test['key'], key( $exoskeleton->rules ) );
+	}
+
+	/**
+	 * Simple method to provide a callback for custom routes during testing
+	 *
+	 * @param mixed $data data passed into the request for this route.
+	 * @return mixed returns the data that was input to provide a valid output.
+	 */
+	public function custom_route_callback( $data ) {
+		return $data;
+	}
+
+
+	/**
+	 * Check limits are honoured if a route is registered with exoskeleton limits.
+	 */
+	function test_pre_registered_custom_route_rules() {
+
+		add_action( 'rest_api_init', function () {
+			register_rest_route( 'exoskeleton/v1', '/test/(?P<id>\d+)', array(
+				'methods' => 'GET',
+				'callback' => [ $this, 'custom_route_callback' ],
+				'exoskeleton' => [
+				  'window' => 10,
+				  'limit' => 5,
+				  'lockout' => 20,
+				],
+			) );
+		} );
+		for ( $request = 1; $request <= 6; ++$request ) {
+			if ( $request < 5 ) {
+				$response = rest_do_request( new WP_REST_Request( 'GET', '/exoskeleton/v1/test/1' ) );
+				$this->assertEquals( 200, $response->status );
+			} else {
+				$this->expectException( Exception::class );
+				$this->expectExceptionMessage( 'locked' );
+				$response = rest_do_request( new WP_REST_Request( 'GET', '/exoskeleton/v1/test/1' ) );
+			}
+		}
+	}
+
+
+	/**
+	 * Check that requests do get properly limited
+	 *
+	 * @dataProvider limitTestingProvider
+	 * @param array $rule exoskeleton rule array.
+	 * @param array $test extra test data.
+	 */
+	public function test_limits_are_applied( $rule, $test ) {
+		if ( empty( $test['method'] ) ) {
+			$test['method'] = $rule['method'];
+		}
+		$this->assertTrue( exoskeleton_add_rule( $rule ) );
+		for ( $request = 1; $request <= $rule['limit'] + 1; ++$request ) {
+			if ( $request < $rule['limit'] ) {
+				$response = rest_do_request( new WP_REST_Request( $test['method'], $rule['route'] ) );
+				$this->assertEquals( 200, $response->status );
+			} else {
+				$this->expectException( Exception::class );
+				$this->expectExceptionMessage( 'locked' );
+				$response = rest_do_request( new WP_REST_Request( $test['method'], $rule['route'] ) );
+			}
+		}
+	}
+
+
+	/**
+	 * Make sure that requests falling outside the window do not get limited.
+	 *
+	 * @dataProvider limitTestingProvider
+	 * @param array $rule exoskeleton rule array.
+	 * @param array $test extra test data.
+	 */
+	public function test_limit_window_expiry( $rule, $test ) {
+		if ( empty( $test['method'] ) ) {
+			$test['method'] = $rule['method'];
+		}
+		$this->assertTrue( exoskeleton_add_rule( $rule ) );
+		for ( $request = 1; $request <= $rule['limit'] + 1; ++$request ) {
+			if ( $request < $rule['limit'] ) {
+				$response = rest_do_request( new WP_REST_Request( $test['method'], $rule['route'] ) );
+				$this->assertEquals( 200, $response->status );
+			} else {
+				sleep( $rule['window'] + 1 );
+				$response = rest_do_request( new WP_REST_Request( $test['method'], $rule['route'] ) );
+				$this->assertEquals( 200, $response->status );
+			}
+		}
+	}
+
+	/**
+	 * Limits should only be applied if the correct method is requested
+	 *
+	 * @dataProvider limitTestingProvider
+	 * @param array $rule exoskeleton rule array.
+	 * @param array $test extra test data.
+	 */
+	public function test_different_methods_not_limited( $rule, $test ) {
+		// Change the test or rule method for testing.
+		if ( empty( $test['method'] ) ) {
+			$test['method'] = 'HEAD';
+		} else {
+			$rule['method'] = 'POST';
+		}
+		$this->assertTrue( exoskeleton_add_rule( $rule ) );
+		for ( $request = 1; $request <= $rule['limit'] + 1; ++$request ) {
+			$response = rest_do_request( new WP_REST_Request( $test['method'], $rule['route'] ) );
+			$this->assertEquals( 200, $response->status );
+		}
+	}
+
+
+
+	/**
+	 * Data provider
+	 *
+	 * @return array exoskeleton rule information and test data.
+	 */
+	public function limitTestingProvider() {
+		return [
+			[
+				'rule' => [
+					'route' => '/wp/v2/posts',
+					'window' => 1,
+					'limit'	=> 3,
+					'lockout' => 5,
+					'method' => 'GET',
+					'treat_head_like_get' => false,
+				],
+				'test' => [
+					'key' => '01dd28291a6b5b95802281831ec3d6f5_GET',
+				],
+			],
+			[
+				'rule' => [
+					'route' => '/wp/v2/categories',
+					'window' => 2,
+					'limit'	=> 6,
+					'lockout' => 5,
+					'method' => 'GET',
+					'treat_head_like_get' => false,
+				],
+				'test' => [
+					'key' => 'fd568c1eb104fbad04765b9f2f0100ed_GET',
+				],
+			],
+			[
+				'rule' => [
+					'route' => '/wp/v2/categories',
+					'window' => 2,
+					'limit'	=> 10,
+					'lockout' => 5,
+					'method' => 'GET',
+					'treat_head_like_get' => true,
+				],
+				'test' => [
+					'method' => 'HEAD',
+					'key' => '6ae5a5054b0a306061f10b9c1b193183_GET',
+				],
+			],
+			[
+				'rule' => [
+					'route' => '/exoskeleton/v1/exoskeleton/10',
+					'window' => 1,
+					'limit'	=> 3,
+					'lockout' => 5,
+					'method' => 'GET',
+					'treat_head_like_get' => false,
+				],
+				'test' => [
+					'key' => 'b09a74d523deb0962e21cafaadc63679_GET',
+				],
+			],
+		];
+	}
+
+}

--- a/tests/test-exoskeleton-rule_validation.php
+++ b/tests/test-exoskeleton-rule_validation.php
@@ -71,6 +71,19 @@ class ExoskeletonRuleValidationTest extends WP_UnitTestCase {
 		$this->assertFalse( $this->invokeMethod( $exoskeleton, 'validate_rule', array( $rule ) ) );
 	}
 
+	/**
+	 * Test validation fails if fields contain invalid data
+	 *
+	 * @dataProvider invalidFieldValueProvider
+	 * @param string $field array field_name => invalid_test_value.
+	 */
+	public function test_validate_rule_fails_invalid_field_values( $field ) {
+		$rule = $this->getValidRuleHelper();
+		$rule[ key( $field ) ] = $field;
+		$exoskeleton = Exoskeleton::get_instance();
+		$this->assertFalse( $this->invokeMethod( $exoskeleton, 'validate_rule', array( $rule ) ) );
+	}
+
 
 	/**
 	 * Data provider
@@ -102,6 +115,34 @@ class ExoskeletonRuleValidationTest extends WP_UnitTestCase {
 			[ 'limit' ],
 			[ 'lockout' ],
 			[ 'treat_head_like_get' ],
+		];
+	}
+
+	/**
+	 * Data provider
+	 *
+	 * @return array Valid exoskeleton rule methods
+	 */
+	public function invalidFieldValueProvider() {
+		return [
+			[
+				[ 'window' => 'string', ],
+			],
+			[
+				[ 'window' => -1, ],
+			],
+			[
+				[ 'limit' => 'string', ],
+			],
+			[
+				[ 'limit' => -1, ],
+			],
+			[
+				[ 'lockout' => 'string', ],
+			],
+			[
+				[ 'treat_head_like_get' => 'string', ],
+			],
 		];
 	}
 


### PR DESCRIPTION
There are failing tests in place for functionality described in the readme which isn't currently supported by the existing code.

> method can also be a comma-separated list of methods, eg: POST,GET,PUT

I have not been able to test the 429 header and the retry-after headers are successfully set in my testing environment.

